### PR TITLE
Añadir llamado a jquery.tepuy desde content

### DIFF
--- a/content.html
+++ b/content.html
@@ -49,6 +49,7 @@
     <script src="js/app.js"></script>
     <script src="js/init.js"></script>
     <script src="js/lang.es.js"></script>
+    <script src="js/jquery.tepuy.js"></script>
     <script src="js/lib.js"></script>
     <script src="js/mobilelib.js"></script>
     <script src="js/stories.js"></script>


### PR DESCRIPTION
Al abrir el paquete SCORM, javascript arroja un error indicando que el método `tepuyMenu` no está definido. Parece que faltó incluir en `content.html` el llamado al archivo `jquery.tepuy.js` a donde fue movido gran parte del código JS de la plantilla.